### PR TITLE
Add analytics dashboard and sidebar

### DIFF
--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -19,4 +19,6 @@ urlpatterns = [
     path('ajax/get-book/<int:book_id>/', views.get_book_data, name='get_book_data'),
     path('ajax/get-accolades/', views.ajax_get_accolades, name='ajax_get_accolades'),
     path('ajax/delete-book/<int:book_id>/', views.delete_book_ajax, name='delete_book_ajax'),
+    path('dashboard/', views.dashboard, name='dashboard'),
+    path('analytics/', views.filtered_analytics, name='filtered_analytics'),
 ]

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -1,0 +1,101 @@
+let distributionChart;
+let authorsChart;
+let publishersChart;
+
+function initializeAnalytics() {
+    $.get(window.analyticsUrl + window.location.search, data => {
+        initializeAnalyticsVisualizations(data);
+    });
+}
+
+function updateAnalyticsAfterSearch() {
+    $.get(window.analyticsUrl + window.location.search, data => {
+        updateAnalyticsVisualizations(data);
+    });
+}
+
+function initializeAnalyticsVisualizations(data) {
+    updateKpis(data);
+    initDistributionChart(data);
+    initAuthorsChart(data);
+    initPublishersChart(data);
+}
+
+function updateAnalyticsVisualizations(data) {
+    updateKpis(data);
+    updateDistributionChart(data);
+    updateAuthorsChart(data);
+    updatePublishersChart(data);
+}
+
+function updateKpis(data) {
+    document.getElementById('filter-total-books').textContent = data.totalBooks;
+    document.getElementById('filter-top5').textContent = data.totalTop5;
+    document.getElementById('filter-top10').textContent = data.totalTop10;
+    const rate = data.totalBooks > 0 ? ((data.totalTop10 / data.totalBooks) * 100).toFixed(1) : '0.0';
+    document.getElementById('filter-bestseller-rate').textContent = rate + '%';
+}
+
+function initDistributionChart(data) {
+    const ctx = document.getElementById('distributionChart').getContext('2d');
+    const top5 = data.totalTop5 || 0;
+    const top10 = (data.totalTop10 || 0) - top5;
+    const other = (data.totalBooks || 0) - top5 - top10;
+    distributionChart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+            labels: ['Top 5', 'Top 10', 'Other'],
+            datasets: [{
+                data: [top5, top10, other],
+                backgroundColor: ['#6772e5', '#45d0a1', '#e2e2e2']
+            }]
+        },
+        options: {responsive:true,maintainAspectRatio:false,plugins:{legend:{position:'bottom'}}}
+    });
+}
+
+function updateDistributionChart(data) {
+    const top5 = data.totalTop5 || 0;
+    const top10 = (data.totalTop10 || 0) - top5;
+    const other = (data.totalBooks || 0) - top5 - top10;
+    distributionChart.data.datasets[0].data = [top5, top10, other];
+    distributionChart.update();
+}
+
+function initAuthorsChart(data) {
+    const ctx = document.getElementById('authorsChart').getContext('2d');
+    const labels = data.topAuthorsTop5.map(a => a.name);
+    const values = data.topAuthorsTop5.map(a => a.count);
+    authorsChart = new Chart(ctx, {
+        type: 'bar',
+        data: {labels: labels, datasets:[{label:'Number of Books',data:values,backgroundColor:'#6772e5',borderRadius:4}]},
+        options: {responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{y:{beginAtZero:true,ticks:{precision:0}},x:{ticks:{display:false}}}}
+    });
+}
+
+function updateAuthorsChart(data) {
+    const labels = data.topAuthorsTop5.map(a => a.name);
+    const values = data.topAuthorsTop5.map(a => a.count);
+    authorsChart.data.labels = labels;
+    authorsChart.data.datasets[0].data = values;
+    authorsChart.update();
+}
+
+function initPublishersChart(data) {
+    const ctx = document.getElementById('publishersChart').getContext('2d');
+    const labels = data.topPublishersTop5.map(p => p.name);
+    const values = data.topPublishersTop5.map(p => p.count);
+    publishersChart = new Chart(ctx, {
+        type: 'bar',
+        data: {labels: labels, datasets:[{label:'Number of Books',data:values,backgroundColor:'#45d0a1',borderRadius:4}]},
+        options: {responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{y:{beginAtZero:true,ticks:{precision:0}},x:{ticks:{display:false}}}}
+    });
+}
+
+function updatePublishersChart(data) {
+    const labels = data.topPublishersTop5.map(p => p.name);
+    const values = data.topPublishersTop5.map(p => p.count);
+    publishersChart.data.labels = labels;
+    publishersChart.data.datasets[0].data = values;
+    publishersChart.update();
+}

--- a/static/js/book-management.js
+++ b/static/js/book-management.js
@@ -319,6 +319,9 @@ function performCombinedSearch() {
                 
                 // Reinitialize components after AJAX update
                 initializeAll(currentSortBy, currentSortDir);
+                if (typeof updateAnalyticsAfterSearch === 'function') {
+                    updateAnalyticsAfterSearch();
+                }
             }
         },
         error: function() {
@@ -609,6 +612,9 @@ $(document).on('click', '.pagination a', function(e) {
             
             // Re-initialize after AJAX update
             initializeAll(currentSortBy, currentSortDir);
+            if (typeof updateAnalyticsAfterSearch === 'function') {
+                updateAnalyticsAfterSearch();
+            }
             
             // Update URL without page reload
             if (history.pushState) {
@@ -663,4 +669,7 @@ function getCookie(name) {
 // Initialize everything when document is ready
 $(document).ready(function() {
     initializeAll(window.initialSortBy || '', window.initialSortDir || 'asc');
+    if (typeof initializeAnalytics === 'function') {
+        initializeAnalytics();
+    }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,8 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
+    {% block extra_css %}{% endblock %}
 </head>
 
 <body>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,76 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block content %}
+<div class="container">
+  <h2>Catalog Dashboard</h2>
+  <div class="row">
+    <div class="col-md-4">
+      <div class="well text-center">
+        <h4>Total Books</h4>
+        <p id="dash-total-books" class="lead"></p>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="well text-center">
+        <h4>Top 5 Accolades</h4>
+        <p id="dash-top5" class="lead"></p>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="well text-center">
+        <h4>Top 10 Accolades</h4>
+        <p id="dash-top10" class="lead"></p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <canvas id="dash-authors"></canvas>
+    </div>
+    <div class="col-md-6">
+      <canvas id="dash-publishers"></canvas>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script>
+  const stats = {{ stats_json|safe }};
+  document.getElementById('dash-total-books').textContent = stats.totalBooks;
+  document.getElementById('dash-top5').textContent = stats.totalTop5;
+  document.getElementById('dash-top10').textContent = stats.totalTop10;
+
+  const ctxA = document.getElementById('dash-authors').getContext('2d');
+  new Chart(ctxA, {
+    type: 'bar',
+    data: {
+      labels: stats.topAuthorsTop5.map(a => a.name),
+      datasets: [{
+        label: 'Top 5 Books',
+        data: stats.topAuthorsTop5.map(a => a.count),
+        backgroundColor: '#6772e5',
+        borderRadius: 4
+      }]
+    },
+    options: {responsive: true, maintainAspectRatio: false, plugins:{legend:{display:false}}}
+  });
+
+  const ctxP = document.getElementById('dash-publishers').getContext('2d');
+  new Chart(ctxP, {
+    type: 'bar',
+    data: {
+      labels: stats.topPublishersTop5.map(p => p.name),
+      datasets: [{
+        label: 'Top 5 Books',
+        data: stats.topPublishersTop5.map(p => p.count),
+        backgroundColor: '#45d0a1',
+        borderRadius: 4
+      }]
+    },
+    options: {responsive: true, maintainAspectRatio: false, plugins:{legend:{display:false}}}
+  });
+</script>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,5 +1,26 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load url_tags %}
+
+<style>
+  .content-container {display:flex;width:100%;gap:20px;}
+  .book-list-container {flex:3;}
+  .analytics-sidebar {flex:2;position:sticky;top:20px;height:calc(100vh - 40px);overflow-y:auto;padding-right:10px;}
+  @media (max-width: 992px){.content-container{flex-direction:column;}.analytics-sidebar{height:auto;position:static;}}
+  .mini-section{background-color:white;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.05);margin-bottom:20px;padding:15px;}
+  .mini-section-header{display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid #f0f0f0;padding-bottom:10px;margin-bottom:15px;}
+  .mini-section-header h3{font-size:1rem;font-weight:600;margin:0;}
+  .mini-chart{height:200px;position:relative;}
+  .mini-kpi-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;margin-bottom:15px;}
+  .mini-kpi-tile{background:#f5f6fa;border-radius:8px;padding:10px;text-align:center;}
+  .mini-kpi-title{font-size:.8rem;color:#888;margin-bottom:5px;}
+  .mini-kpi-value{font-size:1.2rem;font-weight:700;color:#333;}
+  .mini-list{margin:0;padding:0;list-style:none;}
+  .mini-list li{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid #f0f0f0;}
+  .mini-list li:last-child{border-bottom:none;}
+  .mini-list .name{font-weight:500;}
+  .mini-list .count{background:#6772e5;color:white;padding:2px 8px;border-radius:12px;font-size:.8rem;}
+</style>
 
 {% block content %}
 <div class="container-fluid">
@@ -192,8 +213,49 @@
 </div>
 
 
-<div id="search-results">
-    {% include 'partials/book_list.html' %}
+<div class="content-container">
+  <div class="book-list-container">
+    <div id="search-results">
+        {% include 'partials/book_list.html' %}
+    </div>
+  </div>
+  <div class="analytics-sidebar">
+    <div class="mini-section">
+        <div class="mini-section-header"><h3>Results Summary</h3></div>
+        <div class="mini-kpi-grid">
+            <div class="mini-kpi-tile">
+                <div class="mini-kpi-title">Total Books</div>
+                <div class="mini-kpi-value" id="filter-total-books">{{ books.paginator.count }}</div>
+            </div>
+            <div class="mini-kpi-tile">
+                <div class="mini-kpi-title">Top 5 Bestsellers</div>
+                <div class="mini-kpi-value" id="filter-top5">-</div>
+            </div>
+            <div class="mini-kpi-tile">
+                <div class="mini-kpi-title">Top 10 Bestsellers</div>
+                <div class="mini-kpi-value" id="filter-top10">-</div>
+            </div>
+            <div class="mini-kpi-tile">
+                <div class="mini-kpi-title">Bestseller Rate</div>
+                <div class="mini-kpi-value" id="filter-bestseller-rate">-</div>
+            </div>
+        </div>
+    </div>
+    <div class="mini-section">
+        <div class="mini-section-header"><h3>Distribution</h3></div>
+        <div class="mini-chart"><canvas id="distributionChart"></canvas></div>
+    </div>
+    <div class="mini-section">
+        <div class="mini-section-header"><h3>Top Authors</h3></div>
+        <div class="mini-chart"><canvas id="authorsChart"></canvas></div>
+        <ul class="mini-list" id="top-authors-list"></ul>
+    </div>
+    <div class="mini-section">
+        <div class="mini-section-header"><h3>Top Publishers</h3></div>
+        <div class="mini-chart"><canvas id="publishersChart"></canvas></div>
+        <ul class="mini-list" id="top-publishers-list"></ul>
+    </div>
+  </div>
 </div>
 </div>
 {% endblock %}
@@ -211,5 +273,8 @@
     // Pass sorting information to JavaScript
     window.initialSortBy = '{{ sort_by }}';
     window.initialSortDir = '{{ sort_dir }}';
+    window.analyticsUrl = '{% url "filtered_analytics" %}';
 </script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="{% static 'js/analytics.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add extra_css block in base template
- create dashboard view and filtered analytics endpoints
- add analytics charts and KPI sidebar on home page
- load Chart.js and new analytics.js
- update navigation and URLs for analytics

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*