### PR TITLE
Add analytics updates for authors

### DIFF
--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     path('ajax/delete-author/<int:author_id>/', views.delete_author_ajax, name='delete_author_ajax'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('analytics/', views.filtered_analytics, name='filtered_analytics'),
+    path('author-analytics/', views.filtered_author_analytics, name='filtered_author_analytics'),
 ]

--- a/static/js/author-analytics.js
+++ b/static/js/author-analytics.js
@@ -1,0 +1,31 @@
+function initializeAuthorAnalytics() {
+    $.get(window.authorAnalyticsUrl + window.location.search, data => {
+        updateAuthorAnalytics(data);
+    });
+}
+
+function updateAuthorAnalyticsAfterSearch() {
+    $.get(window.authorAnalyticsUrl + window.location.search, data => {
+        updateAuthorAnalytics(data);
+    });
+}
+
+function updateAuthorAnalytics(data) {
+    $('#total-authors').text(data.totalAuthors);
+    $('#authors-with-top5').text(data.authorsWithTop5);
+    $('#authors-with-top10').text(data.authorsWithTop10);
+
+    let listHtml = data.topAuthorsTop5.map(a => `<li><span class="name">${a.name}</span><span class="count">${a.count}</span></li>`).join('');
+    if (!listHtml) listHtml = '<li>No data</li>';
+    $('#top-authors-top5-list').html(listHtml);
+
+    listHtml = data.topAuthorsTop10.map(a => `<li><span class="name">${a.name}</span><span class="count">${a.count}</span></li>`).join('');
+    if (!listHtml) listHtml = '<li>No data</li>';
+    $('#top-authors-top10-list').html(listHtml);
+}
+
+$(document).ready(function() {
+    if (typeof window.authorAnalyticsUrl !== 'undefined') {
+        initializeAuthorAnalytics();
+    }
+});

--- a/static/js/author-management.js
+++ b/static/js/author-management.js
@@ -230,6 +230,9 @@ function performCombinedAuthorSearch() {
             $('#author-results').html(data);
             updateAuthorFilters(params);
             initializeAuthorPage(currentSortBy, currentSortDir);
+            if (typeof updateAuthorAnalyticsAfterSearch === 'function') {
+                updateAuthorAnalyticsAfterSearch();
+            }
             if (history.pushState) {
                 const newUrl = window.location.protocol + '//' + window.location.host + window.location.pathname + '?' + params.toString();
                 window.history.pushState({path: newUrl}, '', newUrl);
@@ -329,6 +332,9 @@ $(document).on('click', '.pagination a', function(e) {
         success: function(data) {
             $('#author-results').html(data);
             initializeAuthorPage(currentSortBy, currentSortDir);
+            if (typeof updateAuthorAnalyticsAfterSearch === 'function') {
+                updateAuthorAnalyticsAfterSearch();
+            }
             if (history.pushState) {
                 window.history.pushState({path: url}, '', url);
             }

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -166,21 +166,21 @@
             <div class="mini-kpi-grid">
               <div class="mini-kpi-tile">
                 <div class="mini-kpi-title">Total Authors</div>
-                <div class="mini-kpi-value">{{ analytics.total_authors }}</div>
+                <div id="total-authors" class="mini-kpi-value">{{ analytics.total_authors }}</div>
               </div>
               <div class="mini-kpi-tile">
                 <div class="mini-kpi-title">With Top 5</div>
-                <div class="mini-kpi-value">{{ analytics.authors_with_top5 }}</div>
+                <div id="authors-with-top5" class="mini-kpi-value">{{ analytics.authors_with_top5 }}</div>
               </div>
               <div class="mini-kpi-tile">
                 <div class="mini-kpi-title">With Top 10</div>
-                <div class="mini-kpi-value">{{ analytics.authors_with_top10 }}</div>
+                <div id="authors-with-top10" class="mini-kpi-value">{{ analytics.authors_with_top10 }}</div>
               </div>
             </div>
           </div>
           <div class="mini-section">
             <div class="mini-section-header"><h3>Top Authors (Top 5)</h3></div>
-            <ul class="mini-list">
+            <ul id="top-authors-top5-list" class="mini-list">
               {% for a in analytics.top_authors_top5 %}
               <li><span class="name">{{ a.name }}</span><span class="count">{{ a.top5_count }}</span></li>
               {% empty %}
@@ -190,7 +190,7 @@
           </div>
           <div class="mini-section">
             <div class="mini-section-header"><h3>Top Authors (Top 10)</h3></div>
-            <ul class="mini-list">
+            <ul id="top-authors-top10-list" class="mini-list">
               {% for a in analytics.top_authors_top10 %}
               <li><span class="name">{{ a.name }}</span><span class="count">{{ a.top10_count }}</span></li>
               {% empty %}
@@ -213,6 +213,8 @@
     book_name: '{{ book_name }}',
     publisher_name: '{{ publisher_name }}'
   };
+  window.authorAnalyticsUrl = '{% url "filtered_author_analytics" %}';
 </script>
 <script src="{% static 'js/author-management.js' %}"></script>
+<script src="{% static 'js/author-analytics.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement API to fetch filtered author analytics
- enable updating author analytics after searches
- show IDs for author analytics widgets
- update author management JS to refresh analytics

## Testing
- `python manage.py test -v 0` *(fails: ModuleNotFoundError: No module named 'django')*